### PR TITLE
feat: Hoist npm scripts to root directory

### DIFF
--- a/contact-duplicate/package-lock.json
+++ b/contact-duplicate/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ui-extensibility-contact-duplicate",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT"
     }
   }

--- a/contact-duplicate/package.json
+++ b/contact-duplicate/package.json
@@ -4,7 +4,9 @@
   "description": "A basic example of a UI Extension built with HubSpot's React developer tools",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "postinstall": "cd ./src/app/extensions/ && npm install",
+    "build": "npm run build --prefix ./src/app/extensions/",
+    "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "repository": {
     "type": "git",

--- a/example-meal-order/package-lock.json
+++ b/example-meal-order/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "example-meal-order",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@hubspot/ui-extensions": "latest"

--- a/example-meal-order/package.json
+++ b/example-meal-order/package.json
@@ -4,7 +4,9 @@
   "description": "Order a meal for your contact",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "postinstall": "cd ./src/app/extensions/ && npm install",
+    "build": "npm run build --prefix ./src/app/extensions/",
+    "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "repository": {
     "type": "git",

--- a/get-started/package-lock.json
+++ b/get-started/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ui-extensions-react-examples",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT"
     }
   }

--- a/get-started/package.json
+++ b/get-started/package.json
@@ -4,7 +4,9 @@
   "description": "Basic example of a UI Extensions built with HubSpot's React developer tools",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "postinstall": "cd ./src/app/extensions/ && npm install",
+    "build": "npm run build --prefix ./src/app/extensions/",
+    "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

This change lets devs run npm scripts from the root of their project, rather than needing to `cd` around once it's cloned.

### Workflow change:

After this change is merged, we can cut out the 2nd step (`cd` into extensions directory):

```patch
 $ cd ui-extensions-react-examples
-$ cd ./src/app/extensions
 $ npm install
 $ npm run dev
```


/cc @sejal27 