### PR TITLE
Update `npm` scripts to use `hs` command

### DIFF
--- a/contact-duplicate/package.json
+++ b/contact-duplicate/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "cd ./src/app/extensions/ && npm install",
-    "build": "npm run build --prefix ./src/app/extensions/",
     "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "repository": {

--- a/contact-duplicate/src/app/extensions/package.json
+++ b/contact-duplicate/src/app/extensions/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "main": "Extension.tsx",
   "scripts": {
-    "dev": "hs-ui-extensions-dev-server dev",
-    "build": "hs-ui-extensions-dev-server build"
+    "dev": "hs project dev"
   },
   "repository": {
     "type": "git",

--- a/example-meal-order/package.json
+++ b/example-meal-order/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "cd ./src/app/extensions/ && npm install",
-    "build": "npm run build --prefix ./src/app/extensions/",
     "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "repository": {

--- a/example-meal-order/src/app/extensions/package.json
+++ b/example-meal-order/src/app/extensions/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "main": "OrderMealExtension.tsx",
   "scripts": {
-    "dev": "hs-ui-extensions-dev-server dev",
-    "build": "hs-ui-extensions-dev-server build"
+    "dev": "hs project dev"
   },
   "repository": {
     "type": "git",

--- a/get-started/package.json
+++ b/get-started/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "cd ./src/app/extensions/ && npm install",
-    "build": "npm run build --prefix ./src/app/extensions/",
     "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "repository": {

--- a/get-started/src/app/extensions/package.json
+++ b/get-started/src/app/extensions/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "main": "Example.jsx",
   "scripts": {
-    "dev": "hs-ui-extensions-dev-server dev",
-    "build": "hs-ui-extensions-dev-server build"
+    "dev": "hs project dev"
   },
   "repository": {
     "type": "git",

--- a/with-crm-components/package.json
+++ b/with-crm-components/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "cd ./src/app/extensions/ && npm install",
-    "build": "npm run build --prefix ./src/app/extensions/",
     "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "repository": {

--- a/with-crm-components/src/app/extensions/package.json
+++ b/with-crm-components/src/app/extensions/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "main": "StageTrackerExtension.tsx",
   "scripts": {
-    "dev": "hs-ui-extensions-dev-server dev",
-    "build": "hs-ui-extensions-dev-server build"
+    "dev": "hs project dev"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR does the following:

- Updates `npm run dev` in the  `package.json` files in `src/app/extensions` to use `hs project dev`
- Removes the `npm run build` in the `package.json` files in `src/app/extensions`
- Removes the shortcut command using `--prefx` in root level of each project.